### PR TITLE
[Feat] #5 Create an assignee card (draft)

### DIFF
--- a/src/components/AssigneeCard.tsx
+++ b/src/components/AssigneeCard.tsx
@@ -1,0 +1,43 @@
+interface AssigneeCardProps {
+  assigneeName: string;
+  dueDate: string;
+  profileImageUrl?: string;
+}
+
+const AssigneeCard: React.FC<AssigneeCardProps> = ({
+  assigneeName,
+  dueDate,
+  profileImageUrl,
+}) => {
+  const initial = assigneeName.charAt(0).toUpperCase();
+  const hasProfileImage = Boolean(profileImageUrl);
+
+  return (
+    <div className="w-[200px] h-[155px] bg-white rounded-[8px] shadow-md p-4 border border-[#d9d9d9]">
+      <div className="mb-3">
+        <h3 className="text-gray-500 text-sm">담당자</h3>
+        <div className="flex items-center space-x-3 mt-1">
+          {hasProfileImage ? (
+            <img
+              src={profileImageUrl}
+              alt={`${assigneeName}의 프로필`}
+              className="w-10 h-10 rounded-full border"
+            />
+          ) : (
+            <div className="w-10 h-10 flex items-center justify-center bg-green-500 text-white rounded-full text-sm font-bold">
+              {initial}
+            </div>
+          )}
+          <span className="text-gray-800 font-medium">{assigneeName}</span>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-gray-500 text-sm">마감일</h3>
+        <p className="text-gray-800 font-medium mt-1">{dueDate}</p>
+      </div>
+    </div>
+  );
+};
+
+export default AssigneeCard;


### PR DESCRIPTION
## 작업 사항
* #5  담당자 카드(초안) 제작
* css의 theme이 정리되는 대로 정확한 스타일 적용 예정
* (현재는 최외부 박스 크기만 맞추어 놓음. Responsive 스타일 미적용)

## 전달 사항
prop으로 넘겨주세요:
- 담당자 이름: assigneeName (string)
- 마감일: dueDate (string)
- 프로필 이미지: profileImageUrl (string)
- 프로필 이미지 값 없을 시: 담당자 이름의 첫글자를 이미지 대신 표시합니다.

![image](https://github.com/user-attachments/assets/56f7602f-744a-4ad3-8c09-25e8695fd7fd)

## 확인 사항
* 라벨을 적용했나요?
* 이슈 내용 적용, close 했나요?
* 담당자 선택했나요?
