### PR TITLE
[Feat] #15 Tailwind 폰트 스타일 적용

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import "@/styles/globals.css";
+import "@/styles/font.css";
 import type { AppProps } from "next/app";
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,56 @@
 export default function Home() {
-  return <>랜딩페이지</>;
+  return (
+    <>
+      <p className="text-3xl-bold">Pretendard 3XL Bold (32px / 42px)</p>
+      <p className="text-3xl-semibold">Pretendard 3XL Semibold (32px / 42px)</p>
+
+      <p className="text-2xl-bold">Pretendard 2XL Bold (24px / 32px)</p>
+      <p className="text-2xl-semibold">Pretendard 2XL Semibold (24px / 32px)</p>
+      <p className="text-2xl-medium">Pretendard 2XL Medium (24px / 32px)</p>
+      <p className="text-2xl-regular">Pretendard 2XL Regular (24px / 32px)</p>
+
+      <p className="text-xl-bold">Pretendard XL Bold (20px / 32px)</p>
+      <p className="text-xl-semibold">Pretendard XL Semibold (20px / 32px)</p>
+      <p className="text-xl-medium">Pretendard XL Medium (20px / 32px)</p>
+      <p className="text-xl-regular">Pretendard XL Regular (20px / 32px)</p>
+
+      <p className="text-lg-bold">Pretendard LG Bold (16px / 26px)</p>
+      <p className="text-lg-semibold">Pretendard LG Semibold (16px / 26px)</p>
+      <p className="text-lg-medium">Pretendard LG Medium (16px / 26px)</p>
+      <p className="text-lg-regular">Pretendard LG Regular (16px / 26px)</p>
+
+      <p className="text-md-bold">Pretendard MD Bold (14px / 24px)</p>
+      <p className="text-md-semibold">Pretendard MD Semibold (14px / 24px)</p>
+      <p className="text-md-medium">Pretendard MD Medium (14px / 24px)</p>
+      <p className="text-md-regular">Pretendard MD Regular (14px / 24px)</p>
+
+      <p className="text-sm-semibold">Pretendard SM Semibold (13px / 22px)</p>
+      <p className="text-sm-medium">Pretendard SM Medium (13px / 22px)</p>
+
+      <p className="text-xs-semibold">Pretendard XS Semibold (12px / 20px)</p>
+      <p className="text-xs-medium">Pretendard XS Medium (12px / 18px)</p>
+      <p className="text-xs-regular">Pretendard XS Regular (12px / 18px)</p>
+
+      <div className="w-64 h-12 bg-black-000000 text-white flex items-center justify-center">#000000</div>
+      <div className="w-64 h-12 bg-black-171717 text-white flex items-center justify-center">#171717</div>
+      <div className="w-64 h-12 bg-black-333236 text-white flex items-center justify-center">#333236</div>
+      <div className="w-64 h-12 bg-black-4B4B4B text-white flex items-center justify-center">#4B4B4B</div>
+
+      <div className="w-64 h-12 bg-gray-787486 text-white flex items-center justify-center">#787486</div>
+      <div className="w-64 h-12 bg-gray-9FA6B2 text-black flex items-center justify-center">#9FA6B2</div>
+      <div className="w-64 h-12 bg-gray-D9D9D9 text-black flex items-center justify-center">#D9D9D9</div>
+      <div className="w-64 h-12 bg-gray-EEEEEE text-black flex items-center justify-center">#EEEEEE</div>
+      <div className="w-64 h-12 bg-gray-FAFAFA text-black flex items-center justify-center">#FAFAFA</div>
+      <div className="w-64 h-12 bg-white-FFFFFF text-black flex items-center justify-center">#FFFFFF</div>
+
+      <div className="w-64 h-12 bg-violet-5534DA text-white flex items-center justify-center">#5534DA</div>
+      <div className="w-64 h-12 bg-violet-F1EFFD text-black flex items-center justify-center">#F1EFFD</div>
+      <div className="w-64 h-12 bg-red-D6173A text-white flex items-center justify-center">#D6173A</div>
+      <div className="w-64 h-12 bg-green-7AC555 text-white flex items-center justify-center">#7AC555</div>
+      <div className="w-64 h-12 bg-purple-760DDE text-white flex items-center justify-center">#760DDE</div>
+      <div className="w-64 h-12 bg-orange-FFA500 text-white flex items-center justify-center">#FFA500</div>
+      <div className="w-64 h-12 bg-blue-76A6EA text-white flex items-center justify-center">#76A6EA</div>
+      <div className="w-64 h-12 bg-pink-E876EA text-white flex items-center justify-center">#E876EA</div>
+    </>
+  );
 }

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,0 +1,222 @@
+@import "tailwindcss";
+
+@theme {
+    --font-pretendard: "Pretendard", sans-serif;
+
+    --font-3xl-bold: 32px;
+    --line-3xl-bold: 42px;
+    --font-3xl-semibold: 32px;
+    --line-3xl-semibold: 42px;
+
+    --font-2xl-bold: 24px;
+    --line-2xl-bold: 32px;
+    --font-2xl-semibold: 24px;
+    --line-2xl-semibold: 32px;
+    --font-2xl-medium: 24px;
+    --line-2xl-medium: 32px;
+    --font-2xl-regular: 24px;
+    --line-2xl-regular: 32px;
+
+    --font-xl-bold: 20px;
+    --line-xl-bold: 32px;
+    --font-xl-semibold: 20px;
+    --line-xl-semibold: 32px;
+    --font-xl-medium: 20px;
+    --line-xl-medium: 32px;
+    --font-xl-regular: 20px;
+    --line-xl-regular: 32px;
+
+    --font-2lg-bold: 18px;
+    --line-2lg-bold: 26px;
+    --font-2lg-semibold: 18px;
+    --line-2lg-semibold: 26px;
+    --font-2lg-medium: 18px;
+    --line-2lg-medium: 26px;
+    --font-2lg-regular: 18px;
+    --line-2lg-regular: 26px;
+
+    --font-lg-bold: 16px;
+    --line-lg-bold: 26px;
+    --font-lg-semibold: 16px;
+    --line-lg-semibold: 26px;
+    --font-lg-medium: 16px;
+    --line-lg-medium: 26px;
+    --font-lg-regular: 16px;
+    --line-lg-regular: 26px;
+
+    --font-md-bold: 14px;
+    --line-md-bold: 24px;
+    --font-md-semibold: 14px;
+    --line-md-semibold: 24px;
+    --font-md-medium: 14px;
+    --line-md-medium: 24px;
+    --font-md-regular: 14px;
+    --line-md-regular: 24px;
+
+    --font-sm-semibold: 13px;
+    --line-sm-semibold: 22px;
+    --font-sm-medium: 13px;
+    --line-sm-medium: 22px;
+
+    --font-xs-semibold: 12px;
+    --line-xs-semibold: 20px;
+    --font-xs-medium: 12px;
+    --line-xs-medium: 18px;
+    --font-xs-regular: 12px;
+    --line-xs-regular: 18px;
+    
+    --breakpoint-tablet: 743px;
+    --breakpoint-laptop: 1023px;
+    --breakpoint-desktop: 1920px;
+}
+
+@layer components {
+    .text-3xl-bold {
+      font-size: var(--font-3xl-bold);
+      line-height: var(--line-3xl-bold);
+      font-weight: 700;
+      font-family: var(--font-pretendard);
+    }
+    .text-3xl-semibold {
+      font-size: var(--font-3xl-semibold);
+      line-height: var(--line-3xl-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+  
+    .text-2xl-bold {
+      font-size: var(--font-2xl-bold);
+      line-height: var(--line-2xl-bold);
+      font-weight: 700;
+      font-family: var(--font-pretendard);
+    }
+    .text-2xl-semibold {
+      font-size: var(--font-2xl-semibold);
+      line-height: var(--line-2xl-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+    .text-2xl-medium {
+      font-size: var(--font-2xl-medium);
+      line-height: var(--line-2xl-medium);
+      font-weight: 500;
+      font-family: var(--font-pretendard);
+    }
+    .text-2xl-regular {
+      font-size: var(--font-2xl-regular);
+      line-height: var(--line-2xl-regular);
+      font-weight: 400;
+      font-family: var(--font-pretendard);
+    }
+  
+    .text-xl-bold {
+      font-size: var(--font-xl-bold);
+      line-height: var(--line-xl-bold);
+      font-weight: 700;
+      font-family: var(--font-pretendard);
+    }
+    .text-xl-semibold {
+      font-size: var(--font-xl-semibold);
+      line-height: var(--line-xl-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+    .text-xl-medium {
+      font-size: var(--font-xl-medium);
+      line-height: var(--line-xl-medium);
+      font-weight: 500;
+      font-family: var(--font-pretendard);
+    }
+    .text-xl-regular {
+      font-size: var(--font-xl-regular);
+      line-height: var(--line-xl-regular);
+      font-weight: 400;
+      font-family: var(--font-pretendard);
+    }
+  
+    .text-lg-bold {
+      font-size: var(--font-lg-bold);
+      line-height: var(--line-lg-bold);
+      font-weight: 700;
+      font-family: var(--font-pretendard);
+    }
+    .text-lg-semibold {
+      font-size: var(--font-lg-semibold);
+      line-height: var(--line-lg-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+    .text-lg-medium {
+      font-size: var(--font-lg-medium);
+      line-height: var(--line-lg-medium);
+      font-weight: 500;
+      font-family: var(--font-pretendard);
+    }
+    .text-lg-regular {
+      font-size: var(--font-lg-regular);
+      line-height: var(--line-lg-regular);
+      font-weight: 400;
+      font-family: var(--font-pretendard);
+    }
+  
+    .text-md-bold {
+      font-size: var(--font-md-bold);
+      line-height: var(--line-md-bold);
+      font-weight: 700;
+      font-family: var(--font-pretendard);
+    }
+    .text-md-semibold {
+      font-size: var(--font-md-semibold);
+      line-height: var(--line-md-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+    .text-md-medium {
+      font-size: var(--font-md-medium);
+      line-height: var(--line-md-medium);
+      font-weight: 500;
+      font-family: var(--font-pretendard);
+    }
+    .text-md-regular {
+      font-size: var(--font-md-regular);
+      line-height: var(--line-md-regular);
+      font-weight: 400;
+      font-family: var(--font-pretendard);
+    }
+  
+    .text-sm-semibold {
+      font-size: var(--font-sm-semibold);
+      line-height: var(--line-sm-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+    .text-sm-medium {
+      font-size: var(--font-sm-medium);
+      line-height: var(--line-sm-medium);
+      font-weight: 500;
+      font-family: var(--font-pretendard);
+    }
+  
+    .text-xs-semibold {
+      font-size: var(--font-xs-semibold);
+      line-height: var(--line-xs-semibold);
+      font-weight: 600;
+      font-family: var(--font-pretendard);
+    }
+    .text-xs-medium {
+      font-size: var(--font-xs-medium);
+      line-height: var(--line-xs-medium);
+      font-weight: 500;
+      font-family: var(--font-pretendard);
+    }
+    .text-xs-regular {
+      font-size: var(--font-xs-regular);
+      line-height: var(--line-xs-regular);
+      font-weight: 400;
+      font-family: var(--font-pretendard);
+    }
+  }
+
+/* .text-3xl-bold { @apply text-3xl font-bold font-pretendard;}
+.text-3xl-semibold { @apply text-[32px]} */
+


### PR DESCRIPTION
### 작업 내용
- Tailwind 폰트 스타일 추가 (`text-3xl-bold`, `text-xl-medium`, `text-sm-regular` 등)

### 변경 사항
- `styles/font.css` → Tailwind 폰트 스타일 추가

### 참고사항
- Tailwind 4.x 방식으로 설정 파일 없이 폰트 스타일 적용 가능