### PR TITLE
[Feat] #5 Assignee card

### DIFF
--- a/src/components/AssigneeCard.tsx
+++ b/src/components/AssigneeCard.tsx
@@ -1,0 +1,43 @@
+interface AssigneeCardProps {
+  assigneeName: string;
+  dueDate: string;
+  profileImageUrl?: string;
+}
+
+const AssigneeCard: React.FC<AssigneeCardProps> = ({
+  assigneeName,
+  dueDate,
+  profileImageUrl,
+}) => {
+  const initial = assigneeName.charAt(0).toUpperCase();
+  const hasProfileImage = Boolean(profileImageUrl);
+
+  return (
+    <div className="w-[200px] h-[155px] bg-white rounded-[8px] shadow-md p-4 border border-[#d9d9d9]">
+      <div className="mb-3">
+        <h3 className="text-gray-500 text-sm">담당자</h3>
+        <div className="flex items-center space-x-3 mt-1">
+          {hasProfileImage ? (
+            <img
+              src={profileImageUrl}
+              alt={`${assigneeName}의 프로필`}
+              className="w-10 h-10 rounded-full border"
+            />
+          ) : (
+            <div className="w-10 h-10 flex items-center justify-center bg-green-500 text-white rounded-full text-sm font-bold">
+              {initial}
+            </div>
+          )}
+          <span className="text-gray-800 font-medium">{assigneeName}</span>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-gray-500 text-sm">마감일</h3>
+        <p className="text-gray-800 font-medium mt-1">{dueDate}</p>
+      </div>
+    </div>
+  );
+};
+
+export default AssigneeCard;

--- a/src/components/AssigneeCard.tsx
+++ b/src/components/AssigneeCard.tsx
@@ -1,7 +1,7 @@
 interface AssigneeCardProps {
   assigneeName: string;
-  dueDate: string;
-  profileImageUrl?: string;
+  dueDate: string | null;
+  profileImageUrl: string | null;
 }
 
 const AssigneeCard: React.FC<AssigneeCardProps> = ({
@@ -10,31 +10,37 @@ const AssigneeCard: React.FC<AssigneeCardProps> = ({
   profileImageUrl,
 }) => {
   const initial = assigneeName.charAt(0).toUpperCase();
-  const hasProfileImage = Boolean(profileImageUrl);
+  const hasProfileImage = profileImageUrl !== null && profileImageUrl !== "";
+  const hasDueDate = dueDate ? dueDate : "마감일 없음";
 
   return (
-    <div className="w-[200px] h-[155px] bg-white rounded-[8px] shadow-md p-4 border border-[#d9d9d9]">
+    <div className="w-[200px] h-[155px] bg-white rounded-[8px] p-4 border border-[#d9d9d9]">
       <div className="mb-3">
         <h3 className="text-gray-500 text-sm">담당자</h3>
         <div className="flex items-center space-x-3 mt-1">
-          {hasProfileImage ? (
-            <img
-              src={profileImageUrl}
-              alt={`${assigneeName}의 프로필`}
-              className="w-10 h-10 rounded-full border"
-            />
-          ) : (
-            <div className="w-10 h-10 flex items-center justify-center bg-green-500 text-white rounded-full text-sm font-bold">
-              {initial}
-            </div>
-          )}
+          <div
+            className={`w-10 h-10 flex items-center justify-center rounded-full text-sm font-bold text-white ${
+              hasProfileImage ? "" : "bg-green-500"
+            }`}
+            style={
+              hasProfileImage
+                ? {
+                    backgroundImage: `url(${profileImageUrl})`,
+                    backgroundSize: "cover",
+                    backgroundPosition: "center",
+                  }
+                : {}
+            }
+          >
+            {!hasProfileImage && initial}
+          </div>
           <span className="text-gray-800 font-medium">{assigneeName}</span>
         </div>
       </div>
 
       <div>
         <h3 className="text-gray-500 text-sm">마감일</h3>
-        <p className="text-gray-800 font-medium mt-1">{dueDate}</p>
+        <p className="text-gray-800 font-medium mt-1">{hasDueDate}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 사항
#5 
* 담당자 카드(초안) 제작
* pc규격
* 프로필 이미지 값이 null이면 담당자 이름의 첫글자표시(임시. 논의 후 기능 조정 예정)
* 마감일 값이 null이면 "마감일 없음" 표시
* 프로필 이미지의 비율에 상관 없이 중앙을 1:1로 크롭해서 표시

## 전달 사항
Props
* 담당자 assigneeName: string;
* 마감일 dueDate: string | null;
* 프로필이미지 profileImageUrl: string | null;

![image](https://github.com/user-attachments/assets/81e80c99-3244-4b9c-a91a-c8996dbbdf02)
![image](https://github.com/user-attachments/assets/e57234ca-7297-421d-bd65-1acdc07d7a6c)

## 확인 사항
* 라벨을 적용했나요?
* 이슈 내용 적용, close 했나요?
* 담당자 선택했나요?
