### PR TITLE
[Fix] Correct duplicate styles in TodoCard by applying media query

### DIFF
--- a/src/components/common/TodoCard.tsx
+++ b/src/components/common/TodoCard.tsx
@@ -28,7 +28,7 @@ const TodoCard: React.FC<TodoCardProps> = ({ todoData }) => {
             >
               <Tags tags={todoData.tags} />
               <div className="flex flex-row items-center gap-[4px]">
-                <div className="bg-[url(@/assets/icons/Calendar.svg)] w-[18px] h-[18px] w-[14px] h-[14px]" />
+                <div className="bg-[url(@/assets/icons/Calendar.svg)] tablet:w-[18px] tablet:h-[18px] w-[14px] h-[14px]" />
                 <p className="text-xs-medium text-gray-787486">
                   {todoData.dueDate}
                 </p>


### PR DESCRIPTION
## 작업 사항
#53 
* 31번 라인 수정
(Calendar.svg의 width & height가 두개씩이었던 것을 미디어쿼리로 나눔)

## 전달 사항
ex) ~ 라이브러리 설치, npm i 하세요

## 확인 사항
* 라벨을 적용했나요?
* 이슈 내용 적용, close 했나요?
* 담당자 선택했나요?
